### PR TITLE
Fix ign regex

### DIFF
--- a/steam_user_review_filter.user.js
+++ b/steam_user_review_filter.user.js
@@ -24,7 +24,7 @@ for (i = 0; i < reviews.length; i++) {
     var urgh = reviews[i].innerText;
     if (urgh.includes('10/10')) {
         $(reviews[i]).remove();
-    } else if (urgh.match(/ign/i)) {
+    } else if (urgh.match(/\bign\b/i)) {
         $(reviews[i]).remove();
     } 
   


### PR DESCRIPTION
Add word boundaries to 'ign' detection so as not to match words with 'ign' substring (like 'design')